### PR TITLE
Set the version as a class param and use it in the files then

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,7 @@
-class java7 {
-	$version = "1.7.0_05"
+class java7($version = '1.7.0_07') {
 	$tarball = $architecture ? {
-		"amd64" => "jdk-7u5-linux-x64.tar.gz",
-		default => "jdk-7u5-linux-i586.tar.gz",
+		"amd64" => "jdk-${version}-linux-x64.tar.gz",
+		default => "jdk-${version}-linux-i586.tar.gz",
 	}
 	
 	package { "java-common":


### PR DESCRIPTION
Hi,

I propose that you set the version number as a param so I can pick it up as a user of the module. The default value was also updated to the current jdk version(hope you don't mind)

Maybe the guide will also need to be updates to instruct the user how he should name his file based on the version he is picking

Best, Nikola
